### PR TITLE
Add optional Lampshade depth sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "lampshade"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a480ddfa3f958b84784306b18c4ab1456bdcbf03dab865740de25f12d10990"
+checksum = "347df873139c2fb370e93d278c14abf01c10db643493dc55c9228413dadffa13"
 dependencies = [
  "bytemuck",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -313,7 +313,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -440,7 +440,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -608,7 +608,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -795,7 +795,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -805,25 +805,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
-name = "futures-task"
-version = "0.3.32"
+name = "futures-executor"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1071,7 +1135,7 @@ checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1101,7 +1165,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1129,7 +1193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1209,6 +1273,18 @@ checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
  "regex-automata",
  "rustversion",
+]
+
+[[package]]
+name = "lampshade"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a480ddfa3f958b84784306b18c4ab1456bdcbf03dab865740de25f12d10990"
+dependencies = [
+ "bytemuck",
+ "futures",
+ "log",
+ "wgpu",
 ]
 
 [[package]]
@@ -1376,7 +1452,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1504,7 +1580,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1910,7 +1986,7 @@ checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1997,7 +2073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2269,7 +2345,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2450,6 +2526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,7 +2593,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2517,7 +2604,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2715,7 +2802,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2917,14 +3004,14 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "wgpu"
-version = "29.0.3"
+version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -2998,6 +3085,7 @@ dependencies = [
  "env_logger",
  "glam",
  "half",
+ "lampshade",
  "log",
  "oneshot",
  "paste",
@@ -3238,7 +3326,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3249,7 +3337,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3483,7 +3571,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3499,7 +3587,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3621,7 +3709,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ wgpu = "29.0"
 wesl = "0.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-lampshade = { version = "0.10", optional = true }
+lampshade = { version = "0.12", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.6", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ multi-model = []
 selection = ["editor"]
 viewer-selection = ["selection"]
 editor = ["dep:wgpu-3dgs-editor"]
+lampshade-sort = ["dep:lampshade"]
 
 [dependencies]
 wgpu-3dgs-core = { version = "0.7" }
@@ -69,6 +70,9 @@ paste = "1.0"
 thiserror = "2.0"
 wgpu = "29.0"
 wesl = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+lampshade = { version = "0.10", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.6", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This library displays 3D Gaussian Splatting models with wgpu. It includes a read
 - Optional features
   - Multi-model: render many models with custom draw orders.
   - Selection: viewport selection (e.g. rectangle, brush) that marks Gaussians for editing.
+  - `lampshade-sort`: accelerate depth sorting on supported NVIDIA/Vulkan subgroup devices, with the existing sorter as fallback. Enable it with `wgpu-3dgs-viewer = { version = "0.7", features = ["lampshade-sort"] }`.
 - Shaders
   - WGSL shaders packaged with WESL, you can extend or replace them.
 
@@ -64,7 +65,17 @@ let gaussians = gs::core::Gaussians::read_from_file(model_path, gs::core::Gaussi
 let camera = gs::Camera::new(0.1..1e4, 60f32.to_radians());
 
 // Create the viewer
-let mut viewer = gs::Viewer::new(&device, config.view_formats[0], &gaussians).expect("viewer");
+// On native targets with the `lampshade-sort` feature, request
+// `adapter.features() & wgpu::Features::SUBGROUP` when creating the device.
+// The accelerated route currently targets NVIDIA/Vulkan; other adapters keep
+// the existing portable sorter.
+let mut viewer = gs::Viewer::new_for_adapter(
+    &device,
+    &adapter.get_info(),
+    config.view_formats[0],
+    &gaussians,
+)
+.expect("viewer");
 
 // Setup camera parameters...
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -129,9 +129,14 @@ impl core::System for System {
             .expect("adapter");
 
         log::debug!("Requesting device");
+        #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+        let required_features = adapter.features() & wgpu::Features::SUBGROUP;
+        #[cfg(not(all(feature = "lampshade-sort", not(target_arch = "wasm32"))))]
+        let required_features = wgpu::Features::empty();
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 label: Some("Device"),
+                required_features,
                 required_limits: adapter.limits(),
                 ..Default::default()
             })
@@ -164,8 +169,13 @@ impl core::System for System {
         let camera = gs::Camera::new(0.1..1e4, 60f32.to_radians());
 
         log::debug!("Creating viewer");
-        let mut viewer =
-            gs::Viewer::new(&device, config.view_formats[0], &gaussians).expect("viewer");
+        let mut viewer = gs::Viewer::new_for_adapter(
+            &device,
+            &adapter.get_info(),
+            config.view_formats[0],
+            &gaussians,
+        )
+        .expect("viewer");
         viewer.update_model_transform(
             &queue,
             Vec3::ZERO,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,55 @@ impl<G: GaussianPod> Viewer<G> {
         gaussians: &impl IterGaussian,
         options: ViewerCreateOptions,
     ) -> Result<Self, ViewerCreateError> {
+        Self::new_with_options_and_adapter(device, None, texture_format, gaussians, options)
+    }
+
+    /// Creates an adapter-aware viewer. With the `lampshade-sort` feature and
+    /// supported NVIDIA/Vulkan subgroup configuration, Gaussian depth sorting
+    /// uses Lampshade's native separate-buffer backend; otherwise it retains
+    /// the existing sorter.
+    pub fn new_for_adapter(
+        device: &wgpu::Device,
+        adapter_info: &wgpu::AdapterInfo,
+        texture_format: wgpu::TextureFormat,
+        gaussians: &impl IterGaussian,
+    ) -> Result<Self, ViewerCreateError> {
+        Self::new_with_options_for_adapter(
+            device,
+            adapter_info,
+            texture_format,
+            gaussians,
+            ViewerCreateOptions::default(),
+        )
+    }
+
+    /// Creates an adapter-aware viewer with extra [`ViewerCreateOptions`]. With
+    /// the `lampshade-sort` feature, supported NVIDIA/Vulkan subgroup devices
+    /// use Lampshade's native separate-buffer sorter; other devices retain the
+    /// existing sorter.
+    pub fn new_with_options_for_adapter(
+        device: &wgpu::Device,
+        adapter_info: &wgpu::AdapterInfo,
+        texture_format: wgpu::TextureFormat,
+        gaussians: &impl IterGaussian,
+        options: ViewerCreateOptions,
+    ) -> Result<Self, ViewerCreateError> {
+        Self::new_with_options_and_adapter(
+            device,
+            Some(adapter_info),
+            texture_format,
+            gaussians,
+            options,
+        )
+    }
+
+    fn new_with_options_and_adapter(
+        device: &wgpu::Device,
+        adapter_info: Option<&wgpu::AdapterInfo>,
+        texture_format: wgpu::TextureFormat,
+        gaussians: &impl IterGaussian,
+        options: ViewerCreateOptions,
+    ) -> Result<Self, ViewerCreateError> {
         log::debug!("Creating camera buffer");
         let camera_buffer = CameraBuffer::new(device);
 
@@ -161,8 +210,19 @@ impl<G: GaussianPod> Viewer<G> {
         )?;
 
         log::debug!("Creating radix sorter");
-        let radix_sorter =
-            RadixSorter::new(device, &gaussians_depth_buffer, &indirect_indices_buffer);
+        let radix_sorter = match adapter_info {
+            #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+            Some(adapter_info) => RadixSorter::new_for_adapter(
+                device,
+                adapter_info,
+                &gaussians_depth_buffer,
+                &indirect_indices_buffer,
+                &indirect_args_buffer,
+            ),
+            #[cfg(not(all(feature = "lampshade-sort", not(target_arch = "wasm32"))))]
+            Some(_) => RadixSorter::new(device, &gaussians_depth_buffer, &indirect_indices_buffer),
+            None => RadixSorter::new(device, &gaussians_depth_buffer, &indirect_indices_buffer),
+        };
 
         log::debug!("Creating renderer");
         let renderer = Renderer::new(

--- a/src/radix_sorter.rs
+++ b/src/radix_sorter.rs
@@ -1,18 +1,28 @@
+#[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+use crate::IndirectArgsBuffer;
 use crate::{
     GaussiansDepthBuffer, IndirectIndicesBuffer, RadixSortIndirectArgsBuffer, core::BufferWrapper,
 };
+use std::sync::OnceLock;
 
 pub type RadixSorterBindGroups = wgpu_sort::InternalSortBuffers;
 
+#[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+struct LampshadeRadixSorter {
+    sorter: lampshade::KeyValueSoaSorter,
+    keys: wgpu::Buffer,
+    values: wgpu::Buffer,
+    count: wgpu::Buffer,
+    capacity: u32,
+}
+
 /// Radix sorter for sorting Gaussians based on their depth (i.e. clipped z value).
-#[derive(Debug)]
 pub struct RadixSorter<B = RadixSorterBindGroups> {
-    /// The sorter.
-    ///
-    /// Using modified version of the [wgpu_sort](https://crates.io/crates/wgpu_sort) crate.
-    sorter: wgpu_sort::GPUSorter,
+    sorter: OnceLock<wgpu_sort::GPUSorter>,
     /// The internal sort buffers.
-    internal_sort_buffers: B,
+    internal_sort_buffers: Option<B>,
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    lampshade: Option<LampshadeRadixSorter>,
 }
 
 impl<B> RadixSorter<B> {
@@ -23,11 +33,13 @@ impl<B> RadixSorter<B> {
         gaussians_depth: &GaussiansDepthBuffer,
         indirect_indices: &IndirectIndicesBuffer,
     ) -> RadixSorterBindGroups {
-        self.sorter.create_internal_sort_buffers(
-            device,
-            gaussians_depth.buffer(),
-            indirect_indices.buffer(),
-        )
+        self.sorter
+            .get_or_init(|| wgpu_sort::GPUSorter::new(device, 1))
+            .create_internal_sort_buffers(
+                device,
+                gaussians_depth.buffer(),
+                indirect_indices.buffer(),
+            )
     }
 }
 
@@ -48,21 +60,97 @@ impl RadixSorter {
 
         Self {
             sorter: this.sorter,
-            internal_sort_buffers,
+            internal_sort_buffers: Some(internal_sort_buffers),
+            #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+            lampshade: None,
         }
     }
 
+    /// Creates the Viewer-owned adapter-aware sorter. The Lampshade backend
+    /// reads the exact count from `indirect_args.instance_count`; its later
+    /// [`sort`](Self::sort) call must therefore remain paired with these Viewer
+    /// buffers. Unsupported devices retain the embedded sorter.
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    pub(crate) fn new_for_adapter(
+        device: &wgpu::Device,
+        adapter_info: &wgpu::AdapterInfo,
+        gaussians_depth: &GaussiansDepthBuffer,
+        indirect_indices: &IndirectIndicesBuffer,
+        indirect_args: &IndirectArgsBuffer,
+    ) -> Self {
+        let capacity = (indirect_indices.buffer().size() / 4) as u32;
+        if let Some(mut sorter) =
+            lampshade::KeyValueSoaSorter::new_for_adapter(device, adapter_info)
+        {
+            match sorter.prepare_counted_from_word(
+                gaussians_depth.buffer(),
+                indirect_indices.buffer(),
+                indirect_args.buffer(),
+                1,
+                capacity,
+            ) {
+                Ok(()) => {
+                    log::debug!("Using Lampshade's native SoA Gaussian sorter");
+                    return Self {
+                        sorter: OnceLock::new(),
+                        internal_sort_buffers: None,
+                        lampshade: Some(LampshadeRadixSorter {
+                            sorter,
+                            keys: gaussians_depth.buffer().clone(),
+                            values: indirect_indices.buffer().clone(),
+                            count: indirect_args.buffer().clone(),
+                            capacity,
+                        }),
+                    };
+                }
+                Err(error) => {
+                    log::warn!(
+                        "Could not prepare Lampshade sorter ({error}); using embedded sorter"
+                    );
+                }
+            }
+        }
+        log::debug!("Using embedded Gaussian sorter");
+        Self::new(device, gaussians_depth, indirect_indices)
+    }
+
     /// Sort the Gaussians based on their depth.
+    ///
+    /// A sorter created by [`Viewer::new_for_adapter`](crate::Viewer::new_for_adapter)
+    /// is coupled to that Viewer's depth, index, and draw-argument buffers. The
+    /// adapter-selected backend reads the exact count from the linked draw
+    /// arguments; `indirect_args_buffer` remains the dispatch source for the
+    /// fallback backend.
     pub fn sort(
         &self,
         encoder: &mut wgpu::CommandEncoder,
         indirect_args_buffer: &RadixSortIndirectArgsBuffer,
     ) {
-        self.sorter.sort_indirect(
-            encoder,
-            &self.internal_sort_buffers,
-            indirect_args_buffer.buffer(),
-        );
+        #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+        if let Some(lampshade) = &self.lampshade {
+            lampshade
+                .sorter
+                .record_reserved_sort_counted_from_word(
+                    encoder,
+                    &lampshade.keys,
+                    &lampshade.values,
+                    &lampshade.count,
+                    1,
+                    lampshade.capacity,
+                )
+                .expect("Lampshade viewer sort recording is valid");
+            return;
+        }
+        self.sorter
+            .get()
+            .expect("legacy sort backend is initialized")
+            .sort_indirect(
+                encoder,
+                self.internal_sort_buffers
+                    .as_ref()
+                    .expect("legacy sort buffers are initialized"),
+                indirect_args_buffer.buffer(),
+            );
     }
 }
 
@@ -75,8 +163,10 @@ impl RadixSorter<()> {
         log::info!("Radix sorter created");
 
         Self {
-            sorter,
-            internal_sort_buffers: (),
+            sorter: OnceLock::from(sorter),
+            internal_sort_buffers: Some(()),
+            #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+            lampshade: None,
         }
     }
 
@@ -91,7 +181,29 @@ impl RadixSorter<()> {
         indirect_args_buffer: &RadixSortIndirectArgsBuffer,
     ) {
         self.sorter
+            .get()
+            .expect("shared sort backend is the legacy implementation")
             .sort_indirect(encoder, bind_groups, indirect_args_buffer.buffer());
+    }
+}
+
+impl<B: std::fmt::Debug> std::fmt::Debug for RadixSorter<B> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RadixSorter")
+            .field("legacy_sorter_initialized", &self.sorter.get().is_some())
+            .field("internal_sort_buffers", &self.internal_sort_buffers)
+            .field("lampshade", &{
+                #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+                {
+                    self.lampshade.is_some()
+                }
+                #[cfg(not(all(feature = "lampshade-sort", not(target_arch = "wasm32"))))]
+                {
+                    false
+                }
+            })
+            .finish_non_exhaustive()
     }
 }
 

--- a/tests/common/test_context.rs
+++ b/tests/common/test_context.rs
@@ -36,4 +36,32 @@ impl TestContext {
             }
         })
     }
+
+    pub fn new_with_subgroups() -> Self {
+        pollster::block_on(async {
+            let instance = wgpu::Instance::new(
+                wgpu::InstanceDescriptor::new_without_display_handle_from_env(),
+            );
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions::default())
+                .await
+                .expect("adapter");
+            let required_features = adapter.features() & wgpu::Features::SUBGROUP;
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor {
+                    label: Some("Subgroup Test Device"),
+                    required_features,
+                    required_limits: adapter.limits(),
+                    ..Default::default()
+                })
+                .await
+                .expect("device");
+            Self {
+                instance,
+                adapter,
+                device,
+                queue,
+            }
+        })
+    }
 }

--- a/tests/e2e/viewer.rs
+++ b/tests/e2e/viewer.rs
@@ -95,6 +95,132 @@ fn test_viewer_render_should_render_correctly() {
     });
 }
 
+#[test]
+fn test_adapter_aware_viewer_render_should_render_correctly() {
+    let ctx = TestContext::new_with_subgroups();
+    let gaussians = vec![Gaussian {
+        rot: Quat::IDENTITY,
+        pos: Vec3::ZERO + Vec3::Z,
+        color: U8Vec4::new(255, 0, 0, 255),
+        sh: [Vec3::ZERO; 15],
+        scale: Vec3::splat(1.0),
+    }];
+    let render_target = given::render_target_texture(&ctx);
+    let adapter_info = ctx.adapter.get_info();
+    let mut viewer = Viewer::<G>::new_for_adapter(
+        &ctx.device,
+        &adapter_info,
+        wgpu::TextureFormat::Rgba8Unorm,
+        &gaussians,
+    )
+    .expect("adapter-aware viewer");
+    let _legacy_bind_groups = viewer.radix_sorter.create_bind_groups(
+        &ctx.device,
+        &viewer.gaussians_depth_buffer,
+        &viewer.indirect_indices_buffer,
+    );
+    viewer.update_camera_with_pod(&ctx.queue, &given::camera_pod());
+    render_and_assert(&ctx, &viewer, &render_target, |pixels: &[UVec4]| {
+        let sum = pixels.iter().sum::<UVec4>();
+        assert!(sum.x > 1);
+        assert!(sum.y < 1);
+        assert!(sum.z < 1);
+        assert!(sum.w > 1);
+    });
+}
+
+#[test]
+fn test_adapter_aware_viewer_renders_without_enabled_subgroups() {
+    let ctx = TestContext::new();
+    assert!(!ctx.device.features().contains(wgpu::Features::SUBGROUP));
+    let gaussians = vec![Gaussian {
+        rot: Quat::IDENTITY,
+        pos: Vec3::ZERO + Vec3::Z,
+        color: U8Vec4::new(255, 0, 0, 255),
+        sh: [Vec3::ZERO; 15],
+        scale: Vec3::splat(1.0),
+    }];
+    let adapter_info = ctx.adapter.get_info();
+    let mut viewer = Viewer::<G>::new_for_adapter(
+        &ctx.device,
+        &adapter_info,
+        wgpu::TextureFormat::Rgba8Unorm,
+        &gaussians,
+    )
+    .expect("fallback viewer");
+    viewer.update_camera_with_pod(&ctx.queue, &given::camera_pod());
+    let render_target = given::render_target_texture(&ctx);
+    render_and_assert(&ctx, &viewer, &render_target, |pixels: &[UVec4]| {
+        assert!(pixels.iter().sum::<UVec4>().x > 1);
+    });
+}
+
+#[test]
+fn test_adapter_aware_viewer_matches_legacy_for_overlapping_multi_gaussian_scene() {
+    let ctx = TestContext::new_with_subgroups();
+    let gaussians: Vec<_> = (0_u32..64)
+        .map(|index| {
+            let column = (index % 4) as f32 - 1.5;
+            let row = ((index / 4) % 4) as f32 - 1.5;
+            let depth_band = (index % 8) as f32;
+            Gaussian {
+                rot: Quat::IDENTITY,
+                pos: Vec3::new(column * 0.08, row * 0.08, 1.0 + depth_band * 0.04),
+                color: U8Vec4::new(
+                    (31 + index * 17) as u8,
+                    (251 - index * 3) as u8,
+                    (67 + index * 11) as u8,
+                    96,
+                ),
+                sh: [Vec3::ZERO; 15],
+                scale: Vec3::splat(0.18),
+            }
+        })
+        .collect();
+    let adapter_info = ctx.adapter.get_info();
+    let mut legacy = Viewer::<G>::new(&ctx.device, wgpu::TextureFormat::Rgba8Unorm, &gaussians)
+        .expect("legacy viewer");
+    let mut adaptive = Viewer::<G>::new_for_adapter(
+        &ctx.device,
+        &adapter_info,
+        wgpu::TextureFormat::Rgba8Unorm,
+        &gaussians,
+    )
+    .expect("adapter-aware viewer");
+    #[cfg(feature = "lampshade-sort")]
+    if adapter_info.backend == wgpu::Backend::Vulkan
+        && adapter_info.vendor == 0x10de
+        && adapter_info.device_type == wgpu::DeviceType::DiscreteGpu
+        && ctx.device.features().contains(wgpu::Features::SUBGROUP)
+    {
+        assert!(
+            format!("{:?}", adaptive.radix_sorter).contains("lampshade: true"),
+            "a compatible NVIDIA/Vulkan device should select Lampshade"
+        );
+    }
+    let camera = given::camera_pod();
+    legacy.update_camera_with_pod(&ctx.queue, &camera);
+    adaptive.update_camera_with_pod(&ctx.queue, &camera);
+    let legacy_target = given::render_target_texture(&ctx);
+    let adaptive_target = given::render_target_texture(&ctx);
+
+    render_and_assert(
+        &ctx,
+        &legacy,
+        &legacy_target,
+        |legacy_pixels: &[UVec4]| {
+            render_and_assert(
+                &ctx,
+                &adaptive,
+                &adaptive_target,
+                |adaptive_pixels: &[UVec4]| {
+                    assert_eq!(adaptive_pixels, legacy_pixels);
+                },
+            );
+        },
+    );
+}
+
 fn test_viewer_when_no_sh0_is_set_should_and_render_as_grayscale(
     update_gaussian_transform: impl FnOnce(&mut Viewer<G>, &wgpu::Queue),
 ) {


### PR DESCRIPTION
## Summary

- adds an opt-in `lampshade-sort` feature backed by published `lampshade 0.12.0`
- adds adapter-aware `Viewer` constructors while preserving every existing constructor and low-level sorter API
- uses Lampshade's native counted SoA sorter on its supported NVIDIA/Vulkan subgroup configuration
- keeps the embedded sorter for unsupported adapters, disabled subgroup features, preparation failures, and wasm targets
- reads the exact GPU-visible instance count from the existing `IndirectArgsBuffer.instance_count` word; no CPU readback is added

## Correctness and compatibility

Revalidated against published Lampshade 0.12.0:

- default configuration: 22 release tests pass
- all features: 46 release tests pass
- upstream all-feature build, strict all-target/all-feature Clippy, formatting, and package checks pass
- a physical RTX/Vulkan test asserts the native backend was selected and compares overlapping multi-Gaussian render output byte-for-byte with the embedded sorter
- a subgroup-disabled test validates the fallback render path
- the optional dependency is excluded on wasm; the repository's existing `wgpu-3dgs-core` wasm build errors remain unchanged and are not addressed here

## Public-scene benchmark

Measured the complete `preprocess + sort + render` submission-to-completion boundary, with command encoding excluded. Each independent process used 3 alternating-order warmups and 11 alternating-order samples. Output equality was validated outside timing.

- scene: Steam Studio `cactus_splat3_30kSteps_719k_splats.ply` (CC0), 695,779 parsed splats
- scene SHA-256: `bf7c775739cde020a45da8cbfb1f274ddf2fe0a3424f29960a21947306751f09`
- resolution: 1024x1024; 1,048,481 non-background pixels
- adapter: RTX 4070 Ti SUPER, Vulkan, NVIDIA driver 591.86
- embedded process medians: `[7.215, 10.310, 8.436, 7.529, 7.489] ms`
- Lampshade process medians: `[2.680, 3.993, 3.084, 2.784, 2.714] ms`
- median of process medians: **7.529 ms -> 2.784 ms (-63.02%)**
- every process produced byte-identical output

Scene/license source: https://note.com/steam_studio/n/ne9736d94f162

The benchmark was recorded on the initial Lampshade 0.10.1 integration and was not rerun for this dependency-only 0.12 refresh. The current 0.12 branch was revalidated for compilation and byte-for-byte output parity. The timing remains intentionally scoped to that measured source, scene, camera, resolution, adapter, driver, and timing boundary; it is not a universal frame-rate claim.
