### PR TITLE
Add optional Lampshade depth sorting for wgpu 30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,10 +824,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
@@ -841,8 +900,13 @@ version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1214,6 +1278,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884f3e747ed2dcee867cda1b0c31a048f9e20de2d916a248949319921a2e666e"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "lampshade"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e812e6ee6701da8821e88648bcfeace908f91b4d84bb45044d75635bfd634923"
+dependencies = [
+ "bytemuck",
+ "futures",
+ "log",
+ "wgpu",
 ]
 
 [[package]]
@@ -2993,6 +3069,7 @@ dependencies = [
  "env_logger",
  "glam",
  "half",
+ "lampshade",
  "log",
  "oneshot",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ multi-model = []
 selection = ["editor"]
 viewer-selection = ["selection"]
 editor = ["dep:wgpu-3dgs-editor"]
+lampshade-sort = ["dep:lampshade"]
 
 [dependencies]
 wgpu-3dgs-core = { version = "0.8" }
@@ -69,6 +70,9 @@ paste = "1.0"
 thiserror = "2.0"
 wgpu = "30.0"
 wesl = "0.4"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+lampshade = { version = "0.13", optional = true }
 
 [dev-dependencies]
 clap = { version = "4.6", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,35 @@ viewer.update_camera(
 viewer.render(&mut encoder, &texture_view);
 ```
 
+## Optional Lampshade depth sorting
+
+The `lampshade-sort` feature enables Lampshade's native counted sorter for
+`Viewer::render` on eligible NVIDIA/Vulkan devices. The embedded sorter remains
+the default and the fallback on unsupported devices, including WebAssembly.
+Low-level `RadixSorter` calls and `MultiModelViewer` are unchanged.
+
+Add the optional viewer feature and a direct dependency for configuring the device:
+
+```toml
+[dependencies]
+wgpu-3dgs-viewer = { version = "0.8", features = ["lampshade-sort"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+lampshade = "0.13"
+```
+
+Apply
+`lampshade::KeyValueSoaSorter::requirements(&adapter)` when creating the device
+(see `examples/simple.rs`). Enabling the Cargo feature alone does not enable
+the required device features and limits. On native targets,
+`viewer.uses_lampshade_sorter()` reports whether its render path will use
+Lampshade. Set `WGPU_BACKEND=vulkan` when running the example on Windows.
+
+The fast path consumes the GPU-written draw `instance_count` without CPU
+readback and prepares its workspace once at construction. It also retains the
+embedded sorter's resources for compatibility, so it uses additional memory.
+Replacing either public indirect-argument buffer restores the embedded path.
+
 ## Examples
 
 See the [examples](https://github.com/LioQing/wgpu-3dgs-viewer/tree/master/examples) directory for usage examples.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -130,10 +130,21 @@ impl core::System for System {
             .expect("adapter");
 
         log::debug!("Requesting device");
+        let required_features = wgpu::Features::empty();
+        let required_limits = adapter.limits();
+        #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+        let (required_features, required_limits) = {
+            let requirements = lampshade::KeyValueSoaSorter::requirements(&adapter);
+            (
+                requirements.features(required_features),
+                requirements.limits(required_limits),
+            )
+        };
         let (device, queue) = adapter
             .request_device(&wgpu::DeviceDescriptor {
                 label: Some("Device"),
-                required_limits: adapter.limits(),
+                required_features,
+                required_limits,
                 ..Default::default()
             })
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,16 @@ impl<G: GaussianPod> Viewer<G> {
         )?;
 
         log::debug!("Creating radix sorter");
+        #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+        let radix_sorter = RadixSorter::new_for_viewer(
+            device,
+            &gaussians_depth_buffer,
+            &indirect_indices_buffer,
+            &indirect_args_buffer,
+            &radix_sort_indirect_args_buffer,
+            len,
+        );
+        #[cfg(not(all(feature = "lampshade-sort", not(target_arch = "wasm32"))))]
         let radix_sorter =
             RadixSorter::new(device, &gaussians_depth_buffer, &indirect_indices_buffer);
 
@@ -267,11 +277,32 @@ impl<G: GaussianPod> Viewer<G> {
         self.gaussian_transform_buffer.update_with_pod(queue, pod);
     }
 
+    /// Whether [`Self::render`] will use the prepared Lampshade depth sorter.
+    ///
+    /// This requires a native device created with Lampshade's advertised
+    /// features and limits. Replacing either indirect-argument buffer selects
+    /// the embedded sorter. The public low-level [`RadixSorter::sort`] API and
+    /// multi-model viewer continue to use the embedded sorter.
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    pub fn uses_lampshade_sorter(&self) -> bool {
+        self.radix_sorter.uses_lampshade(
+            &self.indirect_args_buffer,
+            &self.radix_sort_indirect_args_buffer,
+        )
+    }
+
     /// Render the viewer.
     pub fn render(&self, encoder: &mut wgpu::CommandEncoder, texture_view: &wgpu::TextureView) {
         self.preprocessor
             .preprocess(encoder, self.gaussians_buffer.len() as u32);
 
+        #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+        self.radix_sorter.sort_for_viewer(
+            encoder,
+            &self.indirect_args_buffer,
+            &self.radix_sort_indirect_args_buffer,
+        );
+        #[cfg(not(all(feature = "lampshade-sort", not(target_arch = "wasm32"))))]
         self.radix_sorter
             .sort(encoder, &self.radix_sort_indirect_args_buffer);
 

--- a/src/radix_sorter.rs
+++ b/src/radix_sorter.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+use crate::IndirectArgsBuffer;
 use crate::{
     GaussiansDepthBuffer, IndirectIndicesBuffer, RadixSortIndirectArgsBuffer, core::BufferWrapper,
 };
@@ -13,7 +15,32 @@ pub struct RadixSorter<B = RadixSorterBindGroups> {
     sorter: wgpu_sort::GPUSorter,
     /// The internal sort buffers.
     internal_sort_buffers: B,
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    lampshade: Option<LampshadePlan>,
 }
+
+#[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+struct LampshadePlan {
+    sorter: lampshade::KeyValueSoaSorter,
+    keys: wgpu::Buffer,
+    values: wgpu::Buffer,
+    count: wgpu::Buffer,
+    dispatch: wgpu::Buffer,
+    capacity: u32,
+}
+
+#[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+impl std::fmt::Debug for LampshadePlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LampshadePlan")
+            .field("capacity", &self.capacity)
+            .finish_non_exhaustive()
+    }
+}
+
+// DrawIndirectArgs contains vertex_count followed by instance_count.
+#[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+const INSTANCE_COUNT_WORD: u32 = 1;
 
 impl<B> RadixSorter<B> {
     /// Create the bind groups.
@@ -49,6 +76,91 @@ impl RadixSorter {
         Self {
             sorter: this.sorter,
             internal_sort_buffers,
+            #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+            lampshade: None,
+        }
+    }
+
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    pub(crate) fn new_for_viewer(
+        device: &wgpu::Device,
+        gaussians_depth: &GaussiansDepthBuffer,
+        indirect_indices: &IndirectIndicesBuffer,
+        indirect_args: &IndirectArgsBuffer,
+        dispatch_args: &RadixSortIndirectArgsBuffer,
+        capacity: u32,
+    ) -> Self {
+        // Retain the embedded sorter for the public low-level API and fallback.
+        let mut this = Self::new(device, gaussians_depth, indirect_indices);
+        if let Some(mut sorter) =
+            lampshade::KeyValueSoaSorter::new_native_for_adapter(device, &device.adapter_info())
+        {
+            match sorter.prepare_counted_from_word(
+                gaussians_depth.buffer(),
+                indirect_indices.buffer(),
+                indirect_args.buffer(),
+                INSTANCE_COUNT_WORD,
+                capacity,
+            ) {
+                Ok(()) => {
+                    this.lampshade = Some(LampshadePlan {
+                        sorter,
+                        keys: gaussians_depth.buffer().clone(),
+                        values: indirect_indices.buffer().clone(),
+                        count: indirect_args.buffer().clone(),
+                        dispatch: dispatch_args.buffer().clone(),
+                        capacity,
+                    });
+                    log::debug!("Using Lampshade for Viewer depth sorting");
+                }
+                Err(error) => log::warn!("Could not prepare Lampshade sorter: {error}"),
+            }
+        }
+        this
+    }
+
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    fn plan_for_viewer(
+        &self,
+        indirect_args: &IndirectArgsBuffer,
+        dispatch_args: &RadixSortIndirectArgsBuffer,
+    ) -> Option<&LampshadePlan> {
+        // Viewer exposes these buffers publicly. A replacement must retain the
+        // original dispatch-driven behavior rather than use a stale count.
+        self.lampshade.as_ref().filter(|plan| {
+            plan.count == *indirect_args.buffer() && plan.dispatch == *dispatch_args.buffer()
+        })
+    }
+
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    pub(crate) fn uses_lampshade(
+        &self,
+        indirect_args: &IndirectArgsBuffer,
+        dispatch_args: &RadixSortIndirectArgsBuffer,
+    ) -> bool {
+        self.plan_for_viewer(indirect_args, dispatch_args).is_some()
+    }
+
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    pub(crate) fn sort_for_viewer(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        indirect_args: &IndirectArgsBuffer,
+        dispatch_args: &RadixSortIndirectArgsBuffer,
+    ) {
+        if let Some(plan) = self.plan_for_viewer(indirect_args, dispatch_args) {
+            plan.sorter
+                .record_reserved_sort_counted_from_word(
+                    encoder,
+                    &plan.keys,
+                    &plan.values,
+                    &plan.count,
+                    INSTANCE_COUNT_WORD,
+                    plan.capacity,
+                )
+                .expect("Viewer's prepared Lampshade buffers remain valid");
+        } else {
+            self.sort(encoder, dispatch_args);
         }
     }
 
@@ -77,6 +189,8 @@ impl RadixSorter<()> {
         Self {
             sorter,
             internal_sort_buffers: (),
+            #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+            lampshade: None,
         }
     }
 

--- a/tests/common/test_context.rs
+++ b/tests/common/test_context.rs
@@ -9,6 +9,23 @@ pub struct TestContext {
 
 impl TestContext {
     pub fn new() -> Self {
+        Self::new_with_requirements(|adapter| (wgpu::Features::empty(), adapter.limits()))
+    }
+
+    #[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+    pub fn new_with_lampshade() -> Self {
+        Self::new_with_requirements(|adapter| {
+            let requirements = lampshade::KeyValueSoaSorter::requirements(adapter);
+            (
+                requirements.features(wgpu::Features::empty()),
+                requirements.limits(adapter.limits()),
+            )
+        })
+    }
+
+    fn new_with_requirements(
+        requirements: impl FnOnce(&wgpu::Adapter) -> (wgpu::Features, wgpu::Limits),
+    ) -> Self {
         pollster::block_on(async {
             let instance = wgpu::Instance::new(
                 wgpu::InstanceDescriptor::new_without_display_handle_from_env(),
@@ -19,10 +36,12 @@ impl TestContext {
                 .await
                 .expect("adapter");
 
+            let (required_features, required_limits) = requirements(&adapter);
             let (device, queue) = adapter
                 .request_device(&wgpu::DeviceDescriptor {
                     label: Some("Device"),
-                    required_limits: adapter.limits(),
+                    required_features,
+                    required_limits,
                     ..Default::default()
                 })
                 .await

--- a/tests/e2e/lampshade.rs
+++ b/tests/e2e/lampshade.rs
@@ -1,0 +1,211 @@
+use glam::{Quat, U8Vec4, UVec2, Vec3};
+use wgpu_3dgs_viewer::{
+    CameraPod, IndirectArgsBuffer, RadixSortIndirectArgsBuffer, RadixSorter, Viewer,
+    core::{BufferWrapper, Gaussian, GaussianPodWithShSingleCov3dSingleConfigs, IterGaussian},
+};
+
+use crate::common::{TestContext, given};
+
+type G = GaussianPodWithShSingleCov3dSingleConfigs;
+const WIDTH: u32 = 64;
+
+fn scene(count: u32) -> Vec<Gaussian> {
+    (0..count)
+        .map(|i| Gaussian {
+            rot: Quat::IDENTITY,
+            pos: Vec3::new(
+                (i % 8) as f32 * 0.025 - 0.1,
+                ((i / 8) % 8) as f32 * 0.025 - 0.1,
+                1.0 + i as f32 * 0.001,
+            ),
+            color: U8Vec4::new((i * 17) as u8, (i * 31) as u8, 200, 40),
+            sh: [Vec3::ZERO; 15],
+            scale: Vec3::splat(0.02),
+        })
+        .collect()
+}
+
+fn viewer(ctx: &TestContext, gaussians: &impl IterGaussian) -> Viewer<G> {
+    let mut viewer =
+        Viewer::new(&ctx.device, wgpu::TextureFormat::Rgba8Unorm, gaussians).expect("viewer");
+    viewer.update_camera_with_pod(
+        &ctx.queue,
+        &CameraPod::new(&given::camera(), UVec2::splat(WIDTH)),
+    );
+    viewer
+}
+
+// The existing helper checks channel occupancy, not RGBA equality. Read the
+// actual bytes here to catch depth-order/blending changes.
+fn render_pixels(ctx: &TestContext, viewer: &Viewer<G>) -> (Vec<u8>, u32) {
+    let texture = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Lampshade parity target"),
+        size: wgpu::Extent3d {
+            width: WIDTH,
+            height: WIDTH,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let readback = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Lampshade parity readback"),
+        size: u64::from(WIDTH * WIDTH * 4 + 4),
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = ctx.device.create_command_encoder(&Default::default());
+    viewer.render(&mut encoder, &texture.create_view(&Default::default()));
+    // Draw buffers lack COPY_SRC. Read the GPU count via a storage binding
+    // without changing production usages just for this test.
+    let count = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Visible count copy"),
+        size: 4,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Visible count readback"),
+            source: wgpu::ShaderSource::Wgsl(
+                "@group(0) @binding(0) var<storage, read> args: array<u32>;
+             @group(0) @binding(1) var<storage, read_write> count: u32;
+             @compute @workgroup_size(1) fn main() { count = args[1]; }"
+                    .into(),
+            ),
+        });
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("Visible count readback"),
+            layout: None,
+            module: &shader,
+            entry_point: Some("main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+    let bindings = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Visible count readback"),
+        layout: &pipeline.get_bind_group_layout(0),
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: viewer.indirect_args_buffer.buffer().as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: count.as_entire_binding(),
+            },
+        ],
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&Default::default());
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bindings, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&count, 0, &readback, u64::from(WIDTH * WIDTH * 4), 4);
+    encoder.copy_texture_to_buffer(
+        texture.as_image_copy(),
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(WIDTH * 4),
+                rows_per_image: Some(WIDTH),
+            },
+        },
+        texture.size(),
+    );
+    ctx.queue.submit([encoder.finish()]);
+    let (sender, receiver) = std::sync::mpsc::channel();
+    readback.map_async(wgpu::MapMode::Read, .., move |result| {
+        sender.send(result).expect("readback receiver");
+    });
+    ctx.device
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("device poll");
+    receiver
+        .recv()
+        .expect("map callback")
+        .expect("map readback");
+    let mapped = readback.get_mapped_range(..).expect("mapped bytes");
+    let split = (WIDTH * WIDTH * 4) as usize;
+    let visible = u32::from_le_bytes(mapped[split..].try_into().expect("count bytes"));
+    (mapped[..split].to_vec(), visible)
+}
+
+#[test]
+fn test_lampshade_render_matches_embedded_as_visibility_changes() {
+    let ctx = TestContext::new_with_lampshade();
+    if !lampshade::KeyValueSoaSorter::requirements(&ctx.adapter).accelerated {
+        assert!(
+            std::env::var_os("LAMPSHADE_REQUIRE_ACCELERATED_TESTS").is_none(),
+            "this validation run requires an eligible NVIDIA/Vulkan adapter"
+        );
+        eprintln!("skipping native Lampshade parity: adapter is not eligible");
+        return;
+    }
+
+    // Cross the embedded 3840-item dispatch boundary; keys have distinct depths.
+    let gaussians = scene(3841);
+    let mut accelerated = viewer(&ctx, &gaussians);
+    assert!(accelerated.uses_lampshade_sorter());
+    let mut embedded = viewer(&ctx, &gaussians);
+    embedded.radix_sorter = RadixSorter::new(
+        &ctx.device,
+        &embedded.gaussians_depth_buffer,
+        &embedded.indirect_indices_buffer,
+    );
+    assert!(!embedded.uses_lampshade_sorter());
+
+    // Reuse each prepared viewer across full, partially culled, zero-visible,
+    // and full frames to catch stale counts/workspace on consecutive frames.
+    for shift in [0.0, -2.0, -10.0, 0.0] {
+        for viewer in [&mut accelerated, &mut embedded] {
+            viewer.update_model_transform(&ctx.queue, Vec3::Z * shift, Quat::IDENTITY, Vec3::ONE);
+        }
+        let (expected, expected_count) = render_pixels(&ctx, &embedded);
+        let (actual, visible) = render_pixels(&ctx, &accelerated);
+        assert_eq!(visible, expected_count);
+        if shift == 0.0 {
+            assert_eq!(visible, 3841);
+        } else if shift == -10.0 {
+            assert_eq!(visible, 0);
+        } else {
+            assert!(visible > 0 && visible < 3841);
+        }
+        assert_eq!(actual, expected, "RGBA mismatch at model shift {shift}");
+        let colored = actual.chunks_exact(4).any(|pixel| pixel[..3] != [0, 0, 0]);
+        assert_eq!(colored, shift != -10.0);
+    }
+
+    // Replacing metadata restores the dispatch API; a clone of the original
+    // handle still selects the prepared plan.
+    let draw = accelerated.indirect_args_buffer.clone();
+    accelerated.indirect_args_buffer = IndirectArgsBuffer::new(&ctx.device);
+    assert!(!accelerated.uses_lampshade_sorter());
+    accelerated.indirect_args_buffer = draw;
+    assert!(accelerated.uses_lampshade_sorter());
+    let dispatch = accelerated.radix_sort_indirect_args_buffer.clone();
+    accelerated.radix_sort_indirect_args_buffer = RadixSortIndirectArgsBuffer::new(&ctx.device);
+    assert!(!accelerated.uses_lampshade_sorter());
+    accelerated.radix_sort_indirect_args_buffer = dispatch;
+    assert!(accelerated.uses_lampshade_sorter());
+}
+
+#[test]
+fn test_lampshade_falls_back_without_enabled_subgroups() {
+    let ctx = TestContext::new();
+    assert!(!ctx.device.features().contains(wgpu::Features::SUBGROUP));
+    let fallback = viewer(&ctx, &scene(1));
+    assert!(!fallback.uses_lampshade_sorter());
+    let (pixels, visible) = render_pixels(&ctx, &fallback);
+    assert_eq!(visible, 1);
+    assert!(pixels.chunks_exact(4).any(|pixel| pixel[..3] != [0, 0, 0]));
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(all(feature = "lampshade-sort", not(target_arch = "wasm32")))]
+mod lampshade;
 #[cfg(feature = "multi-model")]
 mod multi_model;
 #[cfg(feature = "viewer-selection")]


### PR DESCRIPTION
@LioQing This replaces #22 for viewer 0.8 / wgpu 30, using the now-published Lampshade 0.13.

- Adds an opt-in `lampshade-sort` feature for `Viewer::render` on eligible NVIDIA/Vulkan devices.
- Prepares the counted sorter once and reads the GPU-written visible count without CPU readback.
- Keeps the embedded sorter as a fallback
  - Existing constructors, low-level sorting, and multi-model behavior are unchanged
  - Its resources remain allocated, so the opt-in uses extra memory.

On a 696K-splat scene at 1024×1024, RTX 4070 Ti SUPER/Vulkan: **5.553 → 2.537 ms GPU preprocess-sort-render time (54.3% lower)**, with byte-identical RGBA. Both paths call `Viewer::render`. [Pinned harness, raw samples, and limitations](https://github.com/SamJSui/lampshade/tree/ad644d34ebbaaf74e32d2afc2c82874859b1b518/benchmarks/3dgs-viewer).

Validation: 
- formatting and strict Clippy
- 19 default and 45 all-feature native tests
- DX12 fallback rendering all-feature rustdoc and packaging
- New regressions cover full/partial/zero visibility, reused workspace, and fallback. 
- Deliberately changing the count word from 1 to 0 makes the parity regression fail; restoring it passes.
